### PR TITLE
Feature/api gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,7 @@ DB_PASSWORD=LOL/A  # <-- 特殊字元現在可以直接使用
 DB_HOST=db
 DB_PORT=5432
 DB_NAME=magic_pinecone_db
+
+# Server URLs for OpenAPI Docs
+GATEWAY_URL=http://localhost:18080
+BACKEND_URL=http://localhost:8000

--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,4 @@ DB_USER=backend
 DB_PASSWORD=LOL/A  # <-- 特殊字元現在可以直接使用
 DB_HOST=db
 DB_PORT=5432
-DB_NAME=amazing_pinecone
+DB_NAME=magic_pinecone_db

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .venv
 .env
+.idea
 .idea/.gitignore
 .idea/MagicPineconeBackend.iml
 .idea/modules.xml

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,30 @@
+:8000 {
+    # Match only API documentation paths
+    @docs_paths {
+        path /docs /docs/* /redoc /redoc/* /openapi.json
+    }
+
+    # Reverse proxy allowed documentation paths
+    handle @docs_paths {
+        reverse_proxy magic_pinecone:8000
+    }
+
+    # Block all other endpoints with 403 Forbidden
+    handle {
+        respond "Access Denied: Direct backend access is restricted to API documentation only." 403
+    }
+
+    encode gzip zstd
+}
+
+:18080 {
+    # Reverse proxy DigiRunner API Gateway
+    reverse_proxy digirunner:18080
+    encode gzip zstd
+}
+
+:8081 {
+    # Reverse proxy Adminer database management UI
+    reverse_proxy adminer:8080
+    encode gzip zstd
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       POSTGRES_DB: ${DB_NAME}
     volumes:
       - postgres_data:/var/lib/postgresql/
-    ports:
+    expose:
       - "5432"
     networks:
       - apim_network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,9 @@ services:
     expose:
       - "8000"
     networks:
-      - apim_network
+      - public_net
+      - app_net
+      - db_net
     depends_on:
       db:
         condition: service_healthy
@@ -19,10 +21,11 @@ services:
   digirunner:
     image: tpisoftwareopensource/digirunner-open-source:release-v4.7.3
     container_name: digirunner_gateway
-    ports:
-      - "18080:18080"
+    expose:
+      - "18080"
     networks:
-      - apim_network
+      - public_net
+      - app_net
     depends_on:
       - magic_pinecone
     restart: unless-stopped
@@ -41,7 +44,7 @@ services:
     expose:
       - "5432"
     networks:
-      - apim_network
+      - db_net
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
       interval: 5s
@@ -52,19 +55,47 @@ services:
   adminer:
     image: adminer:5.4.2
     container_name: magic_pinecone_adminer
-    ports:
-      - '8081:8080'
+    expose:
+      - "8080"
     networks:
-      - apim_network
+      - public_net
+      - db_net
     depends_on:
       - db
 
+  caddy:
+    image: caddy:2.9.1-alpine
+    container_name: magic_pinecone_caddy
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+      - "18080:18080"
+      - "8081:8081"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+      - caddy_data:/data
+      - caddy_config:/config
+    networks:
+      - public_net
+    depends_on:
+      - magic_pinecone
+      - digirunner
+      - adminer
+
 networks:
-  apim_network:
+  public_net:
+    driver: bridge
+  app_net:
+    driver: bridge
+  db_net:
     driver: bridge
 
 volumes:
   postgres_data:
     driver: local
   digirunner_data:
+    driver: local
+  caddy_data:
+    driver: local
+  caddy_config:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ services:
       - .env
     expose:
       - "8000"
-    ports:
-      - "8000:8000"
     networks:
       - apim_network
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
     depends_on:
       - magic_pinecone
     restart: unless-stopped
+    volumes:
+      - digirunner_data:/var/lib/digirunner
 
   db:
     image: postgres:17.10
@@ -37,7 +39,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/
     ports:
-      - "5432:5432"
+      - "5432"
     networks:
       - apim_network
     healthcheck:
@@ -47,10 +49,22 @@ services:
       retries: 5
     restart: unless-stopped
 
+  adminer:
+    image: adminer:5.4.2
+    container_name: magic_pinecone_adminer
+    ports:
+      - '8081:8080'
+    networks:
+      - apim_network
+    depends_on:
+      - db
+
 networks:
   apim_network:
     driver: bridge
 
 volumes:
   postgres_data:
+    driver: local
+  digirunner_data:
     driver: local

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
+import os
 
 from routers import test, course, scholarship
 from database.db_connect import engine
@@ -9,6 +10,10 @@ from internal.scheduler import start_scheduler, scheduler
 import logging
 
 logging.basicConfig(level=logging.INFO)
+
+# Load Server URLs for API Documentation testing (Swagger UI)
+gateway_url = os.getenv("GATEWAY_URL", "http://localhost:18080")
+backend_url = os.getenv("BACKEND_URL", "http://localhost:8000")
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -26,8 +31,13 @@ app = FastAPI(
         'name': 'Shawn Lin',
         'email': 'spig100.roc@gmail.com'
     },
-    lifespan=lifespan
+    lifespan=lifespan,
+    servers=[
+        {"url": gateway_url, "description": "API Gateway (DigiRunner)"},
+        {"url": backend_url, "description": "Direct Backend (Restricted)"}
+    ]
 )
+
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
This pull request introduces significant infrastructure and configuration improvements to enhance security, modularity, and usability of the development environment. The main changes include the introduction of a `Caddy` reverse proxy for secure routing, restructuring of Docker networks, addition of new service containers (Adminer and Caddy), and improved API documentation configuration.

**Infrastructure and Security Enhancements:**

* Added a `Caddy` reverse proxy (`Caddyfile`, `docker-compose.yml`) to restrict direct backend access, allowing only API documentation endpoints and routing all other traffic through the API gateway. [[1]](diffhunk://#diff-1f38639fad43624b85cdc2cac1778918713a061084bca6487683ec73f2b29feaR1-R30) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L41-R101)
* Redesigned Docker networks for better isolation and security by splitting into `public_net`, `app_net`, and `db_net`, and updated service network assignments accordingly. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L12-R15) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L24-R33) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L41-R101)

**Service and Tooling Additions:**

* Added `Adminer` as a database management UI and included its configuration in `docker-compose.yml` and proxy routing in `Caddyfile`. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L41-R101) [[2]](diffhunk://#diff-1f38639fad43624b85cdc2cac1778918713a061084bca6487683ec73f2b29feaR1-R30)
* Introduced persistent storage volumes for `digirunner`, `caddy`, and `adminer` services.

**Configuration and Documentation Improvements:**

* Updated `.env.example` to clarify database name and add environment variables for API Gateway and Backend URLs used in OpenAPI docs.
* Enhanced `main.py` to load and display server URLs in the OpenAPI documentation, making it easier to test via Swagger UI. [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R4) [[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R14-R17) [[3]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L29-R41)