### PR TITLE
Feature/s&pt

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,11 @@ services:
     restart: unless-stopped
     volumes:
       - digirunner_data:/var/lib/digirunner
+    environment:
+      - SPRING_DATASOURCE_URL=jdbc:h2:file:/var/lib/digirunner/dgrdb;DB_CLOSE_DELAY=-1;NON_KEYWORDS=VALUE;Mode=MySQL
+      - SPRING_SQL_INIT_MODE=always
+      - SPRING_SQL_INIT_CONTINUE_ON_ERROR=true
+
 
   db:
     image: postgres:17.10

--- a/internal/scholarship_fetcher.py
+++ b/internal/scholarship_fetcher.py
@@ -1,5 +1,6 @@
 import logging
 import httpx
+import json
 from bs4 import BeautifulSoup
 from sqlalchemy.orm import Session
 from datetime import datetime, timezone
@@ -39,7 +40,26 @@ async def fetch_scholarship_data():
                 
             category = cols[1].get_text(strip=True)
             title = cols[2].get_text(strip=True)
-            content_summary = cols[3].get_text(separator='\n', strip=True).replace('\n下載', ' 下載')
+            
+            # Parse label-value pairs from the column text
+            content_summary_list = []
+            text = cols[3].get_text(separator='\n', strip=True).replace('\n下載', ' 下載')
+            for line in text.split('\n'):
+                line = line.strip()
+                if not line:
+                    continue
+                if ' :' in line:
+                    parts = line.split(' :', 1)
+                elif '：' in line:
+                    parts = line.split('：', 1)
+                elif ':' in line:
+                    parts = line.split(':', 1)
+                else:
+                    parts = ["", line]
+                
+                label = parts[0].strip()
+                value = parts[1].strip()
+                content_summary_list.append({"label": label, "value": value})
             
             # Check for download link in the last column
             download_link = None
@@ -55,7 +75,7 @@ async def fetch_scholarship_data():
             results.append({
                 "category": category,
                 "title": title,
-                "content_summary": content_summary,
+                "content_summary": json.dumps(content_summary_list, ensure_ascii=False),
                 "download_link": download_link
             })
             

--- a/schemas/scholarship_schema.py
+++ b/schemas/scholarship_schema.py
@@ -1,17 +1,53 @@
-from typing import Optional, List
+import json
+from typing import Optional, List, Any
 from datetime import datetime
-from pydantic import BaseModel, Field, ConfigDict
+from pydantic import BaseModel, Field, model_validator, ConfigDict
+
+class ContentSummaryItem(BaseModel):
+    label: str = Field(..., description="摘要項目的名稱/標籤")
+    value: str = Field(..., description="摘要項目的內容/值")
 
 class ScholarshipResponse(BaseModel):
     id: int = Field(..., description="內部資料庫流水號")
     category: str = Field(..., description="類別 (例如：獎學金、招募資訊)")
     title: str = Field(..., description="名稱/標題")
-    content_summary: Optional[str] = Field(None, description="內容摘要 (包含日期與申請資格)")
+    content_summary: Optional[List[ContentSummaryItem]] = Field(None, description="內容摘要 (包含日期與申請資格)")
     download_link: Optional[str] = Field(None, description="相關檔案下載連結")
 
     model_config = ConfigDict(from_attributes=True)
+
+    @model_validator(mode='before')
+    @classmethod
+    def _parse_json_fields(cls, data: Any) -> Any:
+        if hasattr(data, '__dict__'):
+            target = data
+            is_dict = False
+        elif isinstance(data, dict):
+            target = data
+            is_dict = True
+        else:
+            return data
+
+        def _parse(val):
+            if isinstance(val, str):
+                try:
+                    return json.loads(val)
+                except json.JSONDecodeError:
+                    return []
+            if isinstance(val, list):
+                return val
+            return []
+
+        if is_dict:
+            target['content_summary'] = _parse(target.get('content_summary'))
+        else:
+            if hasattr(target, 'content_summary'):
+                target.content_summary = _parse(target.content_summary)
+
+        return data
 
 class ScholarshipResult(BaseModel):
     total_count: int = Field(..., description="符合條件的總筆數")
     last_updated: Optional[datetime] = Field(None, description="資料庫最後更新時間")
     scholarships: List[ScholarshipResponse] = Field(..., description="查詢到的資訊列表")
+


### PR DESCRIPTION
This pull request updates the way scholarship content summaries are parsed, stored, and presented. The main improvement is that content summaries are now structured as lists of label-value pairs rather than plain text, making them easier to process and display. Several code and schema changes were made to support this new format.

**Backend changes for content summary parsing and serialization:**

* The scholarship fetching logic now parses the content summary into a list of label-value pairs, handling different separator characters (`:`, `：`, ` :`) and serializes this list as JSON. [[1]](diffhunk://#diff-a9eb5e89783f53427ca4722b3fb9155574566c020edbc8b2636922b14b3cc05eL42-R62) [[2]](diffhunk://#diff-a9eb5e89783f53427ca4722b3fb9155574566c020edbc8b2636922b14b3cc05eL58-R78)
* The `ScholarshipResponse` schema now expects `content_summary` as a list of `ContentSummaryItem` objects (each with `label` and `value`), and includes a model validator to automatically parse JSON strings into lists when necessary.

**Dependency and environment changes:**

* Added the `json` module import to `internal/scholarship_fetcher.py` to handle serialization.
* Updated the `docker-compose.yml` to set H2 database environment variables for the `digirunner` service, improving local development and initialization.